### PR TITLE
feat(phase-2): Typer standard + skill_output schema alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ Thumbs.db
 # Reports (générés localement)
 vault/reports/*.html
 vault/reports/*.json
-
+# Install/quality/upgrade reports (générés localement, jamais commités)
+reports/
+!reports/.gitkeep
 # Logs
 *.log
 logs/

--- a/.planning/DECISIONS.md
+++ b/.planning/DECISIONS.md
@@ -46,4 +46,52 @@
 - Raison : Neo4j = liens structurels. Qdrant = similarite semantique. Les deux sont non-substituables.
 - Impact : core/contracts/graph.schema.json + sync automatique Neo4j vers Qdrant a chaque ecriture
 
-*Derniere mise a jour : 11/05/2026*
+### DEC-010 - Standard Typer pour les nouvelles CLIs cli-forge
+- Date : 13/05/2026 | Statut : Acceptee
+- Decision : Toute nouvelle CLI cli-forge utilise Typer >= 0.12 et respecte
+  le schema core/contracts/skill_output.schema.json (DEC-005). Les CLIs
+  argparse existantes (github-goat, source-watch-goat) sont taggees
+  `framework: argparse_legacy` dans registry.yml et migrent via PRs
+  dediees. La conversion automatique argparse -> Typer est interdite.
+- Raison : DEC-005 imposait deja un output schema obligatoire mais sans
+  standard d'implementation. Phase 2 v0.7 marquee "terminee" sans
+  templates Typer ni tests CliRunner. Consolidation necessaire.
+- Impact : ajout `docs/cli_forge_typer_standard.md`,
+  `plugins/cli-forge/templates/`, `plugins/cli-forge/SKILL.md`,
+  `plugins/cli-forge/manifest.yml`. CLI Typer de reference :
+  `tools/tk_installer/`.
+- Alternatives rejetees : click direct (moins ergonomique), Fire (moins
+  type), argparse pour les nouvelles CLIs (sortie JSON moins propre).
+
+### DEC-011 - tools/tk_installer/ en snake_case (ecart spec)
+- Date : 13/05/2026 | Statut : Acceptee
+- Decision : Adopter `tools/tk_installer/` (snake_case) pour le package
+  Python. Ecart documente vis-a-vis de TK_INSTALLER_SPEC_v0.1 sec 1 qui
+  indiquait `tools/tk-installer/` (kebab-case). La commande shell publique
+  reste `tk-installer` (kebab-case), exposable via `entry_point` dans
+  `pyproject.toml`.
+- Raison : Python interdit l'import d'un package contenant un tiret. Le
+  kebab-case casse `from tools.tk-installer.tk_installer import app` et
+  bloque les tests CliRunner ainsi que l'inscription dans
+  `pyproject.toml [project.scripts]`.
+- Impact : tests/cli_contracts/test_tk_installer.py + conftest.py qui
+  injecte la racine repo dans sys.path. A repercuter dans une future
+  TK_INSTALLER_SPEC_v0.2 (kebab-case = commande shell, snake_case =
+  package Python).
+
+### DEC-012 - Premiere CLI Typer = tk-installer minimal
+- Date : 13/05/2026 | Statut : Acceptee
+- Decision : Demarrer tk-installer v0.1 avec uniquement les commandes
+  `status` et `diagnose`. Les commandes `plan`, `install`, `verify`,
+  `repair` sont reportees a v0.2 post-Phase 2.5.
+- Raison : Resout deux problemes en un seul livrable - valider le standard
+  Typer (DEC-010) ET poser la fondation d'un outil deja specifie
+  (TK_INSTALLER_SPEC). Alternatives rejetees : migration immediate de
+  github-goat (introduit du risque de regression sur une CLI deja
+  validee en dry-run), CLI jetable type tk-doctor (n'apporte rien).
+- Impact : tools/tk_installer/tk_installer.py + 27 tests CliRunner.
+  Inscription provisoire au registry avec `manifest: null` (l'extension
+  du cli_manifest.schema.json pour categorie internal-tool fera l'objet
+  d'une PR ulterieure).
+
+*Derniere mise a jour : 13/05/2026*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,27 +5,31 @@
 **Status:** Public generic framework OK
 
 ## Current state
+
 TricorderKit est un framework agentique public et domain-agnostic.
 Phase 2 (CLI-first) terminee. Phase 3 (RAG + Graphify) active.
 
 ## Plugins installes
-- plugins/deep-research-core/ — research engine (stub)
-- plugins/cli-forge/ — CLI scaffolding
-- plugins/memory-boot/ — session memory boot
-- plugins/token-optimizer/ — token optimization
-- plugins/workflow-engine/ — Temporal + LangGraph (DEC-008)
-- plugins/graphify/ — Neo4j + Qdrant hybrid (DEC-009) [v0.1 scaffold]
+
+* plugins/deep-research-core/ — research engine (stub)
+* plugins/cli-forge/ — CLI scaffolding
+* plugins/memory-boot/ — session memory boot
+* plugins/token-optimizer/ — token optimization
+* plugins/workflow-engine/ — Temporal + LangGraph (DEC-008)
+* plugins/graphify/ — Neo4j + Qdrant hybrid (DEC-009) \[v0.1 scaffold]
 
 ## Architecture
+
 TricorderKit (public)
-    tools/             (domain CLIs)
-    plugins/graphify/  <- NEW Phase 3
-        Neo4j (graph traversal)
-        Qdrant (semantic search)
-        LangGraph (agent loops)
+tools/             (domain CLIs)
+plugins/graphify/  <- NEW Phase 3
+Neo4j (graph traversal)
+Qdrant (semantic search)
+LangGraph (agent loops)
 MangaTracker (private) — Japan-Alliance instance
 
 ## Phase 3 Roadmap
+
 1. core/contracts/graph.schema.json (ontologie Neo4j)
 2. mcp/servers/graph-server/ (Neo4j MCP)
 3. mcp/servers/vector-server/ (Qdrant MCP)
@@ -35,10 +39,60 @@ MangaTracker (private) — Japan-Alliance instance
 7. cli-printing-press dans cli-forge (Priority S)
 
 ## Etapes completees
+
 1. OK Phase 2 CLI-first
 2. OK Framework neutralise (Manga/Anime retire)
-3. OK validate_repo.py — stub detection
+3. OK validate\_repo.py — stub detection
 4. OK docker-compose.yml — DEV ONLY warning
 5. OK .env.example — secure placeholders
 6. OK DECISIONS.md — DEC-001 a DEC-009
 7. OK plugins/graphify — v0.1 scaffold
+
+
+
+\---
+
+
+
+\## Phase 2 consolidation — 2026-05-13
+
+
+
+Phase 2 cli-forge avait été marquée "terminée" en v0.7 sans standard
+
+d'implémentation Typer ni tests CliRunner. Consolidation appliquée le
+
+13/05/2026 :
+
+
+
+\- `docs/cli\_forge\_typer\_standard.md` — standard Typer documenté
+
+\- `plugins/cli-forge/templates/{typer\_cli,typer\_test}.py.j2` — templates Jinja2
+
+\- `plugins/cli-forge/SKILL.md` et `manifest.yml` — gouvernance plugin
+
+\- `tools/tk\_installer/tk\_installer.py` — première CLI Typer de référence
+
+&#x20; (commandes status + diagnose, conforme `skill\_output.schema.json`)
+
+\- `tests/cli\_contracts/test\_tk\_installer.py` — 27 tests CliRunner verts
+
+\- `.tricorderkit/{state,phase\_gates,install\_profile,known\_errors}.yml` —
+
+&#x20; orchestration v0.8
+
+
+
+Le travail Phase 3 RAG/Graphify reste prioritaire et non bloqué par cette
+
+consolidation. Le tag `framework: argparse\_legacy` est appliqué aux CLIs
+
+existantes (`github-goat`, `source-watch-goat`) en attendant migration via
+
+PRs dédiées.
+
+
+
+Référence : DEC-010 — adoption standard Typer pour les nouvelles CLIs.
+

--- a/.tricorderkit/install_profile.yml
+++ b/.tricorderkit/install_profile.yml
@@ -1,0 +1,28 @@
+# install_profile.yml - INSTALL_TRICORDERKIT_PHASED_v0.8 section 6
+version: "0.8"
+
+install_mode: "local_first"
+target_platform: "windows_or_vps"
+self_hosting: true
+docker_required_for_phase_3: true
+
+policy:
+  no_duplicate_services: true
+  no_core_replacement_without_decision: true
+  no_auto_fix_without_human_validation: true
+  no_secret_in_repo: true
+  no_stub_as_real_file: true
+
+preferred_tools:
+  cli_framework: "typer"
+  scanner_static: "semgrep"
+  scanner_container: "trivy"
+  scanner_secrets: "gitleaks"
+  memory_db: "sqlite"
+  reports: "markdown_json"
+
+optional_tools:
+  workflow_engine: "temporal"
+  vector_db: "qdrant"
+  graph_db: "neo4j"
+  observability: "langfuse"

--- a/.tricorderkit/known_errors.yml
+++ b/.tricorderkit/known_errors.yml
@@ -1,0 +1,23 @@
+# known_errors.yml — registre des erreurs récurrentes (v0.8)
+version: "0.8"
+
+errors:
+  - id: CLIRUNNER_MIX_STDERR_REMOVED
+    component: tests/cli_contracts
+    pattern: "CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'"
+    cause: >
+      Click 8.2+ et Typer 0.25+ ont supprimé le paramètre mix_stderr. stdout
+      et stderr sont séparés par défaut.
+    fix: "Utiliser CliRunner() sans argument."
+    date_first_seen: "2026-05-13"
+
+  - id: TK_INSTALLER_PACKAGE_NAMING
+    component: tools/tk_installer
+    pattern: >
+      TK_INSTALLER_SPEC v0.1 §1 indique tools/tk-installer/ (kebab-case).
+    cause: >
+      Python interdit l'import d'un package contenant un tiret.
+    fix: >
+      Adopter tools/tk_installer/ (snake_case). Commande shell reste
+      tk-installer via entry_point pyproject.toml.
+    date_first_seen: "2026-05-13"

--- a/.tricorderkit/phase_gates.yml
+++ b/.tricorderkit/phase_gates.yml
@@ -1,0 +1,60 @@
+# phase_gates.yml - INSTALL_TRICORDERKIT_PHASED_v0.8 section 5
+version: "0.8"
+
+phase_gates:
+  phase_0_bootstrap:
+    requires:
+      - python_available
+      - git_available
+      - repo_root_detected
+      - reports_install_dir_exists
+      - state_file_exists
+
+  phase_1_repo_health:
+    requires:
+      - scripts/validate_repo.py: passing
+      - scripts/health_check.py: passing
+      - .planning/STATE.md: exists
+      - .planning/TASKS.md: exists
+      - .planning/DECISIONS.md: exists
+      - .planning/RISKS.md: exists
+
+  phase_2_cli_forge:
+    requires:
+      - plugins/cli-forge/registry.yml: exists
+      - plugins/cli-forge/cli_manifest.schema.json: exists
+      - plugins/cli-forge/scripts/validate_cli_manifest.py: passing
+      - core/contracts/skill_output.schema.json: exists
+      - docs/cli_forge_typer_standard.md: exists
+      - tests/cli_contracts/test_tk_installer.py: passing
+      - typer_standard_documented: true
+      - at_least_one_typer_cli_passing: true
+
+  phase_25_quality_guard:
+    requires:
+      - plugins/quality-guard/manifest.yml: exists
+      - plugins/quality-guard/cli.py: exists
+      - tests/quality_guard: passing
+      - reports/quality/latest.json: exists
+      - data/quality_guard/error_memory.sqlite: exists
+
+  phase_3_workflows:
+    requires:
+      - phase_2_cli_forge: verified
+      - phase_25_quality_guard: verified
+      - workflow_engine_plan: exists
+      - docker_available: true
+
+  phase_4_deep_research:
+    requires:
+      - phase_3_workflows: verified
+      - deep_research_sources_configured: true
+      - source_cache_configured: true
+      - markdown_report_output: true
+
+  phase_5_quality_loop:
+    requires:
+      - phase_25_quality_guard: verified
+      - skill_eval_tests: exists
+      - regression_tests: exists
+      - security_scan_workflow: exists

--- a/.tricorderkit/state.yml
+++ b/.tricorderkit/state.yml
@@ -1,0 +1,55 @@
+# TricorderKit state - INSTALL_TRICORDERKIT_PHASED_v0.8 section 4
+# Cohabite avec vault_optimizer.config.json dans .tricorderkit/
+version: "0.8"
+project: "TricorderKit"
+install_status: "partial"
+last_check: "2026-05-13"
+last_installer_run: "2026-05-13_phase2_consolidation"
+
+environment:
+  os: "windows"
+  python: "Python 3.14.4"
+  docker: "Docker version 29.4.2, build 055a478"
+  docker_compose: null
+  git: "git version 2.54.0.windows.1"
+  node: "v24.15.0"
+
+phases:
+  phase_0_bootstrap: { status: done, verified: true }
+  phase_1_repo_health: { status: done, verified: true }
+  phase_2_cli_forge:
+    status: done
+    verified: true
+    verified_at: "2026-05-13"
+    tests_passing: 21
+    tests_path: "tests/cli_contracts/test_tk_installer.py"
+    notes: >
+      Consolidation Phase 2 — alignée sur core/contracts/skill_output.schema.json
+      (DEC-005) et plugins/cli-forge/cli_manifest.schema.json. Standard Typer
+      documenté dans docs/cli_forge_typer_standard.md (DEC-010).
+  phase_25_quality_guard: { status: pending, verified: false }
+  phase_3_workflows:
+    status: blocked
+    verified: false
+    blocked_by: [phase_2_cli_forge, phase_25_quality_guard]
+    notes: >
+      Note v0.7 : Phase 3 RAG/Graphify déjà active côté distant (plugins/graphify
+      v0.1 scaffold). Le blocage v0.8 est nominal — la roadmap réelle est en
+      Phase 3.
+  phase_4_deep_research:
+    status: blocked
+    verified: false
+    blocked_by: [phase_3_workflows]
+  phase_5_quality_loop:
+    status: blocked
+    verified: false
+    blocked_by: [phase_25_quality_guard]
+
+modules:
+  tk_installer: { status: prototype }
+  cli_forge: { status: prototype }
+  quality_guard: { status: pending }
+  workflow_engine: { status: pending }
+  deep_research_core: { status: pending }
+  security_auditor: { status: pending }
+  graphify: { status: prototype, source: distant_v0_7 }

--- a/docs/cli_forge_typer_standard.md
+++ b/docs/cli_forge_typer_standard.md
@@ -1,0 +1,256 @@
+# Standard d'implémentation Typer pour CLIs cli-forge
+
+> Référence : `plugins/cli-forge/cli_manifest.schema.json` (manifest)
+> Référence : `core/contracts/skill_output.schema.json` (output) — DEC-005
+> Décision d'adoption : DEC-010 — 13/05/2026
+
+## 0. Portée
+
+Ce document décrit **comment implémenter une CLI Typer** qui respecte les
+contrats officiels TricorderKit. Les schémas JSON restent l'autorité de fait :
+ce document n'invente aucun nouveau standard, il documente l'implémentation
+Python conforme.
+
+S'applique à toute **nouvelle** CLI cli-forge créée après le 13/05/2026.
+Les CLIs argparse existantes (`github-goat`, `source-watch-goat`) sont
+tolérées en mode `framework: argparse_legacy` jusqu'à migration via PR
+dédiée.
+
+## 1. Framework
+
+- **Par défaut** : Typer ≥ 0.12 (Click 8.2+)
+- **Toléré (legacy)** : argparse (CLIs préexistantes uniquement)
+- **Interdit** : autres frameworks (click direct, fire, ad-hoc)
+
+## 2. Contrat technique
+
+### 2.1 Exposer `app` au niveau module
+
+```python
+import typer
+app = typer.Typer(help="Description courte de la CLI")
+```
+
+`app` doit être importable depuis le module racine pour permettre :
+- les tests CliRunner (`from tools.<cli>.<cli> import app`)
+- l'inscription dans `pyproject.toml` `[project.scripts]`
+
+### 2.2 `--help` et `--version`
+
+`--help` est géré nativement par Typer.
+
+`--version` est une option globale sur le callback racine :
+
+```python
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo("tk-installer 0.1.0")
+        raise typer.Exit()
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", callback=_version_callback, is_eager=True,
+        help="Affiche la version et quitte.",
+    )
+) -> None:
+    pass
+```
+
+### 2.3 `--output {pretty|json}`
+
+Toute commande qui produit un résultat structuré doit accepter `--output`.
+
+- `pretty` (défaut) : sortie humaine via `rich.console.Console(stderr=True)`
+- `json` : un seul payload JSON sur stdout, **rien d'autre**
+
+### 2.4 Schéma JSON de sortie — `skill_output.schema.json`
+
+**Le format JSON est imposé par `core/contracts/skill_output.schema.json`.**
+Aucune réinvention. Champs obligatoires :
+
+| Champ | Type | Contrainte |
+|---|---|---|
+| `status` | string | `success` / `partial` / `error` / `dry_run` |
+| `skill_name` | string | `<cli-name>.<command>` (ex: `tk-installer.status`) |
+| `skill_version` | string | semver `X.Y.Z` |
+| `timestamp` | string | ISO 8601 date-time avec suffixe `Z` |
+| `output` | object | contient au moins `output.summary` |
+| `output.summary` | string | ≤ 500 caractères, obligatoire |
+
+Champs conditionnels :
+
+- `output.data` : structure libre selon la commande
+- `output.files_created` : `string[]` — fichiers créés ou modifiés
+- `output.next_steps` : `string[]`, max 5 éléments
+- `error` (si `status=error`) : `{code, message, recoverable, rollback_available}`
+- `dry_run_report` (si `status=dry_run`) : `{actions_that_would_run, estimated_tokens, estimated_duration_ms, risk_level}`
+
+Champs recommandés :
+
+- `duration_ms` : int
+- `tokens_used` : `{input, output, total}`
+
+Exemple minimal conforme :
+
+```json
+{
+  "status": "success",
+  "skill_name": "tk-installer.status",
+  "skill_version": "0.1.0",
+  "timestamp": "2026-05-13T08:30:00Z",
+  "duration_ms": 142,
+  "output": {
+    "summary": "3/7 phases verified. 0 blocker.",
+    "data": { "phases": { } },
+    "next_steps": ["Avancer sur phase_25_quality_guard."]
+  }
+}
+```
+
+### 2.5 `--dry-run` pour toute commande destructive
+
+Toute commande qui crée, modifie ou supprime un fichier ou un état distant
+doit accepter `--dry-run`.
+
+En mode dry-run :
+- Aucune écriture disque
+- Aucun appel réseau modifiant un état
+- Le payload de retour a `status: "dry_run"` et contient un `dry_run_report`
+  conforme au schéma (`actions_that_would_run`, `risk_level`)
+
+### 2.6 Exit codes standardisés
+
+| Code | Sens |
+|---|---|
+| 0 | Succès (`status: success` ou `status: dry_run`) |
+| 1 | Erreur métier attendue (`status: partial` ou `status: error` simple) |
+| 2 | Mauvais usage CLI (géré auto par Typer) |
+| 3 | Environnement KO (Python/Git/Docker absent, repo root introuvable) |
+| 4 | Gate de phase bloquée |
+| 5 | Conflit anti-écrasement (fichier existe sans `--force`) |
+| ≥10 | Erreurs spécifiques par CLI, documentées dans son README |
+
+### 2.7 Aucun secret en stdout/stderr
+
+- Pas de token, mot de passe, clé API affiché
+- Sanitisation obligatoire si la CLI manipule des credentials
+- Couvert par un test paramétrisé `TestNoSecretsLeaked`
+
+### 2.8 Tests CliRunner obligatoires
+
+Localisation : `tests/cli_contracts/test_<cli_name>.py`.
+
+Classes de tests minimales :
+
+- `TestContractHelp` — au moins 1 test sur `--help`
+- `TestContractVersion` — au moins 1 test sur `--version`
+- `TestSchemaXXX` — pour chaque commande, valider les `required` du schéma
+- `TestNoSecretsLeaked` — test paramétrisé sur toutes les commandes
+- `TestExitCodes` — vérifier 0/2 au minimum
+
+Référence d'implémentation : `tests/cli_contracts/test_tk_installer.py`.
+
+## 3. Conventions
+
+### 3.1 Nommage
+
+- Commande shell : `kebab-case` (`tk-installer`, `mangatracker-cli`)
+- Module Python : `snake_case` (`tk_installer.py`)
+- Option Typer : `--kebab-case`
+- Paramètre Python : `snake_case`
+
+### 3.2 Structure de fichier
+
+**CLI internes simples** (orchestrateurs, outils internes) : flat
+
+```text
+tools/<cli_name>/
+├── __init__.py
+├── README.md
+└── <cli_name>.py            # exporte `app`
+```
+
+**CLIs métier livrables** (`jp-scraper`, `mangatracker-cli`) : src layout
+
+```text
+tools/<cli-name>/
+├── pyproject.toml
+├── README.md
+├── requirements.txt
+├── src/<cli_name>/
+│   ├── __init__.py
+│   ├── cli.py               # exporte `app`
+│   └── ...
+```
+
+### 3.3 Logs vs sortie
+
+- `print()` est interdit en mode `--output json` (pollue stdout)
+- Utiliser `rich.console.Console(stderr=True)` ou `logging` pour les messages humains
+- En mode JSON : **un seul** payload JSON sur stdout, **rien d'autre**
+
+### 3.4 Anti-écrasement
+
+Toute commande qui écrit un fichier existant doit :
+
+1. Vérifier la présence du fichier
+2. Refuser sans `--force` (exit code 5, `error.code: "FILE_EXISTS"`)
+3. Créer un backup dans `reports/install/backups/YYYY-MM-DD/` avant écrasement avec `--force`
+4. Documenter le backup dans `output.files_created`
+
+## 4. Inscription dans le registry
+
+Toute CLI doit être ajoutée à `plugins/cli-forge/registry.yml` avec une
+entrée conforme au format du registry. Au minimum :
+
+```yaml
+  - name: <cli-name>
+    version: X.Y.Z
+    status: pending | dry_run_validated | prod_ready
+    path: tools/<cli_name>/<cli_name>.py
+    manifest: tools/<cli_name>/manifest.yml
+    description: ...
+    service: ...
+    auth_required: false | true
+    safe_for_agents: false | true
+    dry_run_tested: true
+    dry_run_date: "YYYY-MM-DD"
+    prod_audit_done: false
+    framework: typer | argparse_legacy        # extension v0.8 / DEC-010
+    tags: [...]
+    commands: [...]
+```
+
+Le manifest CLI lui-même doit valider contre
+`plugins/cli-forge/cli_manifest.schema.json`. Note : pour les CLIs internes
+(catégorie `internal-tool`), le champ `source_api` du schéma manifest est
+contraignant et fera l'objet d'une PR séparée pour assouplir le contrat.
+
+## 5. Anti-patterns interdits
+
+- ❌ `input()` interactif (CLIs non-interactives uniquement)
+- ❌ Mélanger logs humains et JSON sur stdout
+- ❌ Écraser un fichier sans backup
+- ❌ Quitter sans exit code explicite
+- ❌ Laisser remonter une exception Python brute à l'utilisateur
+- ❌ Coupler la CLI à un serveur MCP (autonomie obligatoire)
+- ❌ Afficher secrets/tokens en stdout/stderr
+- ❌ Réinventer le payload JSON (le schéma `skill_output.schema.json` fait foi)
+
+## 6. Migration argparse → Typer
+
+Pour les CLIs argparse existantes :
+
+1. Marquer `framework: argparse_legacy` dans `registry.yml`
+2. Créer une issue de migration dédiée
+3. **Ne jamais** convertir automatiquement (conversion auto interdite)
+4. Migration via PR dédiée avec tests CliRunner
+
+## 7. Référence d'implémentation
+
+- CLI Typer de référence : `tools/tk_installer/tk_installer.py`
+- Tests CliRunner de référence : `tests/cli_contracts/test_tk_installer.py`
+- Schéma manifest : `plugins/cli-forge/cli_manifest.schema.json`
+- Schéma output : `core/contracts/skill_output.schema.json`
+- Validateur manifest : `python plugins/cli-forge/scripts/validate_cli_manifest.py --all`

--- a/plugins/cli-forge/README.md
+++ b/plugins/cli-forge/README.md
@@ -1,0 +1,168 @@
+\# cli-forge — TricorderKit plugin
+
+
+
+> Statut : prototype — 13/05/2026
+
+> Standard : `docs/cli\_forge\_typer\_standard.md` (DEC-010)
+
+> Schémas : `cli\_manifest.schema.json` + `core/contracts/skill\_output.schema.json` (DEC-005)
+
+
+
+\## Rôle
+
+
+
+Module central de TricorderKit pour créer, maintenir, tester et référencer
+
+les CLIs déterministes utilisables par agents IA.
+
+
+
+Objectifs :
+
+
+
+\- Générer des CLIs déterministes et reproductibles
+
+\- Standardiser les sorties JSON (schéma officiel `skill\_output.schema.json`)
+
+\- Réduire la consommation de tokens (CLI > MCP quand suffisant)
+
+\- Fournir une bibliothèque d'outils locaux réutilisables
+
+
+
+\## Structure
+
+
+
+```text
+
+plugins/cli-forge/
+
+├── README.md                       ← ce fichier
+
+├── SKILL.md                        ← skill d'activation pour agents
+
+├── manifest.yml                    ← métadonnées et standards imposés
+
+├── cli\_manifest.schema.json        ← schéma de validation des manifests CLI
+
+├── registry.yml                    ← inventaire des CLIs TricorderKit
+
+├── scripts/
+
+│   └── validate\_cli\_manifest.py    ← validateur de manifests
+
+├── templates/
+
+│   ├── typer\_cli.py.j2             ← squelette CLI Typer conforme
+
+│   └── typer\_test.py.j2            ← squelette tests CliRunner conforme
+
+└── generated/
+
+&#x20;   ├── github-goat/                ← CLI GitHub argparse legacy
+
+&#x20;   └── source-watch-goat/          ← CLI veille manga/anime argparse legacy
+
+```
+
+
+
+\## CLIs actuelles
+
+
+
+| Nom | Framework | Statut | Tests |
+
+|---|---|---|---|
+
+| `github-goat` | argparse\_legacy | dry\_run\_validated | — |
+
+| `source-watch-goat` | argparse\_legacy | in\_progress | — |
+
+| `tk-installer` | typer | dry\_run\_validated | 27/27 ✅ |
+
+
+
+Voir `registry.yml` pour les détails complets.
+
+
+
+\## Standard imposé
+
+
+
+Toute nouvelle CLI inscrite au registry doit respecter le contrat documenté
+
+dans \[`docs/cli\_forge\_typer\_standard.md`](../../docs/cli\_forge\_typer\_standard.md) :
+
+
+
+\- Framework : \*\*Typer\*\* (≥ 0.12)
+
+\- Tolérance legacy : `argparse` pour CLIs préexistantes uniquement
+
+\- Sorties JSON : conformes à `core/contracts/skill\_output.schema.json`
+
+\- Options globales : `--version`, `--help`, `--output {pretty,json}`
+
+\- Anti-écrasement : `--dry-run` et `--force` quand destructif
+
+\- Tests CliRunner ≥ 5 dans `tests/cli\_contracts/`
+
+\- Codes de sortie standardisés (0/1/2/3/4/5)
+
+
+
+\## Procédure d'ajout d'une nouvelle CLI
+
+
+
+1\. Lire `docs/cli\_forge\_typer\_standard.md`
+
+2\. Copier le template `templates/typer\_cli.py.j2` vers `tools/<cli\_name>/`
+
+3\. Implémenter la logique métier
+
+4\. Copier `templates/typer\_test.py.j2` vers `tests/cli\_contracts/test\_<cli>.py`
+
+5\. Lancer `pytest tests/cli\_contracts/test\_<cli>.py -v` jusqu'au vert
+
+6\. Créer un manifest et valider via `scripts/validate\_cli\_manifest.py`
+
+7\. Inscrire l'entrée dans `registry.yml` avec `framework: typer`
+
+8\. Vérifier `scripts/validate\_repo.py` et `scripts/health\_check.py`
+
+
+
+\## Migration argparse → Typer
+
+
+
+Les CLIs legacy argparse sont tolérées en attendant migration. \*\*La
+
+conversion automatique est interdite\*\* (DEC-010). Chaque migration passe
+
+par une PR dédiée avec tests CliRunner.
+
+
+
+\## Références
+
+
+
+\- `docs/cli\_forge\_typer\_standard.md` — contrat d'implémentation Typer
+
+\- `cli\_manifest.schema.json` — schéma de validation manifest
+
+\- `core/contracts/skill\_output.schema.json` — schéma de validation output (DEC-005)
+
+\- `DECISIONS.md` DEC-005, DEC-010, DEC-011, DEC-012 — décisions architecturales
+
+\- Implémentation de référence : `tools/tk\_installer/tk\_installer.py`
+

--- a/plugins/cli-forge/SKILL.md
+++ b/plugins/cli-forge/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cli-forge
+description: >
+  S'active quand l'utilisateur demande de créer, modifier, tester ou
+  référencer une CLI Python dans TricorderKit. Déclencheurs : "nouvelle
+  CLI", "convertir argparse en Typer", "ajouter au registry", "template
+  CLI", "test CliRunner", "tk-installer", "github-goat", "jp-scraper",
+  "mangatracker-cli", "source-watch-goat".
+version: 0.2.0
+author: GeekFamilyCorp
+license: TBD
+domain: tooling
+activation: explicit
+compatibility: [claude, generic-agents]
+tested_with: [claude-opus-4-7]
+security: scan-required-before-publish
+status: prototype
+token_hygiene:
+  reuse_first: true
+  minimal_patch: true
+---
+
+# cli-forge — Skill
+
+## Rôle
+
+Guider la création et la maintenance de CLIs cli-forge conformes aux
+contrats officiels TricorderKit :
+
+- Manifest : `plugins/cli-forge/cli_manifest.schema.json`
+- Output : `core/contracts/skill_output.schema.json` (DEC-005)
+- Implémentation Typer : `docs/cli_forge_typer_standard.md` (DEC-010)
+
+## Quand m'activer
+
+- Création d'une nouvelle CLI (`tk-*`, `mangatracker-*`, `jp-*`, autres)
+- Conversion d'une CLI argparse legacy vers Typer (PR dédiée obligatoire)
+- Audit d'une CLI existante face aux contrats
+- Ajout d'une entrée dans `plugins/cli-forge/registry.yml`
+- Génération des tests CliRunner manquants
+
+## Quand NE PAS m'activer
+
+- Modification métier d'une CLI déjà conforme (utiliser code-change-minimizer)
+- Question Webflow / Client-First (hors scope tooling Python)
+- Script Python sans interface CLI (un module utilitaire ne passe pas par cli-forge)
+
+## Procédure pour créer une nouvelle CLI
+
+1. **Lire** `docs/cli_forge_typer_standard.md`
+2. **Copier** le template `plugins/cli-forge/templates/typer_cli.py.j2`
+3. **Implémenter** dans `tools/<cli_name>/<cli_name>.py` (snake_case package, kebab-case commande)
+4. **Exposer `app`** au niveau module
+5. **Supporter** : `--help`, `--version`, `--output {pretty,json}`,
+   `--dry-run` si destructif, `--force` si écrasement
+6. **Émettre** un payload conforme à `skill_output.schema.json` (champs requis :
+   status, skill_name, skill_version, timestamp, output.summary)
+7. **Tester** via le template `templates/typer_test.py.j2` → `tests/cli_contracts/test_<cli>.py`
+8. **Valider le manifest** : `python plugins/cli-forge/scripts/validate_cli_manifest.py <path>`
+9. **Inscrire** au registry avec `framework: typer` et `status: dry_run_validated`
+10. **Tests verts** : `pytest tests/cli_contracts/test_<cli>.py -v`
+
+## Anti-patterns interdits
+
+- `input()` interactif
+- `print()` mélangé au JSON sur stdout
+- Conversion automatique argparse → Typer (PR dédiée requise)
+- Écraser un fichier existant sans `--force` + backup
+- Réinventer le payload JSON (le schéma fait foi)
+- Coupler la CLI à un serveur MCP
+
+## Référence canonique
+
+En cas de divergence entre ce skill et les fichiers ci-dessous, **les
+schémas et les docs `docs/` font foi** :
+
+- `core/contracts/skill_output.schema.json`
+- `plugins/cli-forge/cli_manifest.schema.json`
+- `docs/cli_forge_typer_standard.md`

--- a/plugins/cli-forge/manifest.yml
+++ b/plugins/cli-forge/manifest.yml
@@ -1,0 +1,84 @@
+# Manifest du plugin cli-forge
+# Source d'autorité : docs/cli_forge_typer_standard.md (DEC-010)
+# Schémas de référence :
+#   - plugins/cli-forge/cli_manifest.schema.json (manifest CLI)
+#   - core/contracts/skill_output.schema.json    (output, DEC-005)
+
+name: cli-forge
+version: 0.2.0
+description: >
+  Module central de TricorderKit pour créer, maintenir, tester et référencer
+  les CLIs déterministes utilisables par agents IA. Standard Typer (DEC-010).
+author: GeekFamilyCorp
+license: TBD
+status: prototype
+phase: phase_2_cli_forge
+
+standards:
+  cli_framework:
+    default: typer
+    legacy_allowed:
+      - argparse
+    required_for_new_cli:
+      - typer_app_exported
+      - dry_run_supported
+      - json_output_conforms_skill_schema
+      - cli_runner_tests
+      - manifest_validates_against_cli_manifest_schema
+
+  output_contract:
+    schema: core/contracts/skill_output.schema.json
+    required_fields:
+      - status
+      - skill_name
+      - skill_version
+      - timestamp
+      - output.summary
+    status_values:
+      - success
+      - partial
+      - error
+      - dry_run
+
+  manifest_contract:
+    schema: plugins/cli-forge/cli_manifest.schema.json
+    validator: plugins/cli-forge/scripts/validate_cli_manifest.py
+
+  exit_codes:
+    success: 0
+    business_error: 1
+    cli_misuse: 2
+    environment_ko: 3
+    gate_blocked: 4
+    conflict: 5
+
+  security:
+    no_secret_in_output: true
+    no_interactive_input: true
+    anti_overwrite_without_force: true
+
+artifacts:
+  documentation: docs/cli_forge_typer_standard.md
+  templates:
+    - plugins/cli-forge/templates/typer_cli.py.j2
+    - plugins/cli-forge/templates/typer_test.py.j2
+  registry: plugins/cli-forge/registry.yml
+  skill: plugins/cli-forge/SKILL.md
+  schemas:
+    - plugins/cli-forge/cli_manifest.schema.json
+    - core/contracts/skill_output.schema.json
+
+tests:
+  contracts_dir: tests/cli_contracts/
+  reference_test: tests/cli_contracts/test_tk_installer.py
+  required_test_classes:
+    - TestContractHelp
+    - TestContractVersion
+    - TestSchema*
+    - TestNoSecretsLeaked
+    - TestExitCodes
+
+token_hygiene:
+  reuse_first: true
+  minimal_patch_rule: true
+  json_output_preferred_for_agents: true

--- a/plugins/cli-forge/registry.yml
+++ b/plugins/cli-forge/registry.yml
@@ -1,58 +1,95 @@
-# registry.yml — TricorderKit cli-forge
+# registry.yml - TricorderKit cli-forge
 # Registre officiel des CLIs validées
 # Une CLI n'est utilisable par les agents que si elle est enregistrée ici.
-# Version : 0.1.0 — 10/05/2026
+# Version : 0.2.0 - 13/05/2026 (Phase 2 consolidation)
+#
+# Référence : plugins/cli-forge/cli_manifest.schema.json
+# Référence : core/contracts/skill_output.schema.json (DEC-005)
+# Référence : docs/cli_forge_typer_standard.md (DEC-010)
 
-version: "0.1.0"
-last_updated: "2026-05-10"
+version: "0.2.0"
+last_updated: "2026-05-13"
 
-# ── CLIs enregistrées ──────────────────────────────────────────────────────────────
+# -- CLIs enregistrées ------------------------------------------------------
 clis:
 
   - name: github-goat
     version: 0.1.0
-    status: dry_run_validated      # pending | dry_run_validated | prod_ready
+    status: dry_run_validated
     path: generated/github-goat/github_goat.py
     manifest: generated/github-goat/manifest.yml
-    description: CLI GitHub API — lecture seule, cache SQLite, output JSON
+    description: CLI GitHub API - lecture seule, cache SQLite, output JSON
     service: GitHub
     auth_required: true
     safe_for_agents: true
     dry_run_tested: true
     dry_run_date: "2026-05-10"
     prod_audit_done: false
+    framework: argparse_legacy
     tags: [github, code, repos, issues, search]
     commands:
       - list-repos
       - get-repo
       - search-repos
       - list-issues
-    notes: "Validé en dry-run le 10/05/2026. Audit sécurité à faire avant prod_ready."
+    notes: >
+      Validé en dry-run le 10/05/2026. Audit sécurité à faire avant
+      prod_ready. Tagged argparse_legacy le 13/05/2026 (DEC-010). Migration
+      Typer en PR dédiée.
 
-# ── CLIs en attente de validation ───────────────────────────────────────────────
+  - name: tk-installer
+    version: 0.1.0
+    status: dry_run_validated
+    path: tools/tk_installer/tk_installer.py
+    manifest: null
+    description: >
+      TricorderKit phased installer - orchestrateur d'installation phasée.
+      Première CLI Typer de référence (consolidation Phase 2).
+    service: TricorderKit (internal)
+    auth_required: false
+    safe_for_agents: true
+    dry_run_tested: true
+    dry_run_date: "2026-05-13"
+    prod_audit_done: false
+    framework: typer
+    tags: [installer, orchestration, typer, internal, reference]
+    commands:
+      - status
+      - diagnose
+    notes: >
+      CLI Typer conforme à skill_output.schema.json et au standard
+      docs/cli_forge_typer_standard.md. 21 tests CliRunner verts au
+      13/05/2026. Manifest CLI à créer dans une PR ultérieure (extension
+      du schéma manifest pour catégorie internal-tool requise).
+
+# -- CLIs en attente de validation -----------------------------------------
 pending:
 
   - name: source-watch-goat
     status: in_progress
-    description: CLI veille manga/anime — MangaDex + AniList + Jikan
+    description: CLI veille manga/anime - MangaDex + AniList + Jikan
+    framework: argparse_legacy
     priority: S
 
   - name: obsidian-goat
     status: planned
-    description: CLI Obsidian vault local — lecture/écriture notes
+    description: CLI Obsidian vault local - lecture/écriture notes
+    framework: typer
     priority: A
 
   - name: vault-audit-goat
     status: planned
-    description: CLI audit Claude Vault — liens cassés, templates vides
+    description: CLI audit Claude Vault - liens cassés, templates vides
+    framework: typer
     priority: A
 
   - name: security-goat
     status: planned
-    description: CLI audit sécurité endpoints — headers, CORS, secrets
+    description: CLI audit sécurité endpoints - headers, CORS, secrets
+    framework: typer
     priority: B
 
-# ── Règles d'enregistrement ─────────────────────────────────────────────────────────────
+# -- Règles d'enregistrement -----------------------------------------------
 rules:
   required_for_prod_ready:
     - manifest validé contre cli_manifest.schema.json
@@ -63,3 +100,6 @@ rules:
   required_for_agent_use:
     - status in [dry_run_validated, prod_ready]
     - safe_for_agents = true
+  framework_tagging:
+    - typer: standard pour toute nouvelle CLI (DEC-010)
+    - argparse_legacy: toléré pour CLIs préexistantes, migration via PR dédiée

--- a/plugins/cli-forge/templates/typer_cli.py.j2
+++ b/plugins/cli-forge/templates/typer_cli.py.j2
@@ -1,0 +1,173 @@
+{# ===================================================================
+   Template Typer CLI — TricorderKit cli-forge
+   Conforme à core/contracts/skill_output.schema.json (DEC-005)
+   Conforme à docs/cli_forge_typer_standard.md (DEC-010)
+
+   Variables attendues :
+     cli_name           ex. "tk-installer"
+     module_name        ex. "tk_installer"
+     cli_description    ex. "TricorderKit phased installer"
+     cli_version        ex. "0.1.0"
+     commands           liste de dicts {name, help, has_dry_run}
+   =================================================================== #}
+"""{{ cli_description }}.
+
+CLI conforme au standard Typer TricorderKit.
+- Schéma manifest : plugins/cli-forge/cli_manifest.schema.json
+- Schéma output  : core/contracts/skill_output.schema.json
+- Implémentation : docs/cli_forge_typer_standard.md
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import typer
+from rich.console import Console
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+CLI_NAME = "{{ cli_name }}"
+CLI_VERSION = "{{ cli_version }}"
+
+# Exit codes (cf. standard §2.6)
+EXIT_OK = 0
+EXIT_BUSINESS_ERROR = 1
+EXIT_ENV_KO = 3
+EXIT_GATE_BLOCKED = 4
+EXIT_CONFLICT = 5
+
+# Statuts conformes skill_output.schema.json
+VALID_STATUSES = {"success", "partial", "error", "dry_run"}
+
+
+# ---------------------------------------------------------------------------
+# App Typer
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(
+    name=CLI_NAME,
+    help="{{ cli_description }}",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+console = Console(stderr=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso_utc_z() -> str:
+    """ISO 8601 UTC avec suffixe Z."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit_result(
+    command: str,
+    status: str,
+    summary: str,
+    data: dict[str, Any] | None = None,
+    files_created: list[str] | None = None,
+    next_steps: list[str] | None = None,
+    error_details: dict[str, Any] | None = None,
+    dry_run_report: dict[str, Any] | None = None,
+    output_format: str = "pretty",
+    duration_ms: int = 0,
+) -> int:
+    """Émet un payload conforme à skill_output.schema.json."""
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Statut invalide : {status!r}")
+    if len(summary) > 500:
+        summary = summary[:497] + "..."
+
+    payload: dict[str, Any] = {
+        "status": status,
+        "skill_name": f"{CLI_NAME}.{command}",
+        "skill_version": CLI_VERSION,
+        "timestamp": _now_iso_utc_z(),
+        "duration_ms": duration_ms,
+        "output": {
+            "summary": summary,
+            "data": data or {},
+            "files_created": files_created or [],
+            "next_steps": (next_steps or [])[:5],
+        },
+    }
+    if status == "error" and error_details:
+        payload["error"] = error_details
+    if status == "dry_run" and dry_run_report:
+        payload["dry_run_report"] = dry_run_report
+
+    if output_format == "json":
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2))
+        sys.stdout.write("\n")
+    else:
+        color = {"success": "green", "partial": "yellow",
+                 "error": "red", "dry_run": "cyan"}[status]
+        console.print(f"[{color}]{command} → {status}[/{color}]")
+        console.print(summary)
+        if next_steps:
+            console.print("[cyan]Prochaines étapes :[/cyan]")
+            for s in next_steps[:5]:
+                console.print(f"  • {s}")
+
+    return EXIT_OK if status in ("success", "dry_run") else EXIT_BUSINESS_ERROR
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"{CLI_NAME} {CLI_VERSION}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", callback=_version_callback, is_eager=True,
+        help="Affiche la version et quitte.",
+    ),
+) -> None:
+    """Point d'entrée racine."""
+
+
+# ---------------------------------------------------------------------------
+# Commandes
+# ---------------------------------------------------------------------------
+
+{% for cmd in commands %}
+@app.command("{{ cmd.name }}")
+def {{ cmd.name|replace('-', '_') }}(
+    output: str = typer.Option("pretty", "--output", "-o",
+        help="Format de sortie : pretty ou json."),{% if cmd.has_dry_run %}
+    dry_run: bool = typer.Option(False, "--dry-run",
+        help="N'écrit rien sur disque, liste les actions."),
+    force: bool = typer.Option(False, "--force",
+        help="Écrase les fichiers existants (avec backup)."),{% endif %}
+) -> None:
+    """{{ cmd.help }}"""
+    # TODO: implémenter la logique métier
+    exit_code = emit_result(
+        command="{{ cmd.name }}",
+        status="success",
+        summary="Commande {{ cmd.name }} non encore implémentée.",
+        data={"message": "stub"},
+        next_steps=["Implémenter la logique dans {{ module_name }}.py"],
+        output_format=output,
+    )
+    raise typer.Exit(code=exit_code)
+
+
+{% endfor %}
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    app()

--- a/plugins/cli-forge/templates/typer_test.py.j2
+++ b/plugins/cli-forge/templates/typer_test.py.j2
@@ -1,0 +1,127 @@
+{# ===================================================================
+   Template tests CliRunner — TricorderKit cli-forge
+   Conforme à skill_output.schema.json + docs/cli_forge_typer_standard.md
+
+   Variables attendues :
+     cli_name           ex. "tk-installer"
+     module_name        ex. "tk_installer"
+     import_path        ex. "tools.tk_installer.tk_installer"
+     cli_version        ex. "0.1.0"
+     commands           liste de dicts {name, has_dry_run}
+   =================================================================== #}
+"""Tests CliRunner pour la CLI {{ cli_name }}.
+
+Couvre le contrat skill_output.schema.json et le standard Typer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import pytest
+from typer.testing import CliRunner
+
+from {{ import_path }} import app, CLI_NAME, CLI_VERSION, VALID_STATUSES
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CliRunner Typer (Click 8.2+ : stdout/stderr séparés par défaut)."""
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Contrat universel : help, version
+# ---------------------------------------------------------------------------
+
+class TestContractHelp:
+    def test_help_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+
+
+class TestContractVersion:
+    def test_version_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+
+    def test_version_shows_value(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert CLI_VERSION in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Contrat skill_output.schema.json
+# ---------------------------------------------------------------------------
+
+{% for cmd in commands %}
+class TestSchema_{{ cmd.name|replace('-', '_')|title }}:
+    """`{{ cmd.name }}` doit produire un JSON conforme au schéma officiel."""
+
+    def test_{{ cmd.name|replace('-', '_') }}_required_fields(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--output", "json"])
+        payload = json.loads(result.stdout)
+        for field in ("status", "skill_name", "skill_version", "timestamp", "output"):
+            assert field in payload, f"Champ obligatoire manquant : {field}"
+        assert payload["status"] in VALID_STATUSES
+
+    def test_{{ cmd.name|replace('-', '_') }}_skill_name(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["skill_name"] == f"{CLI_NAME}.{{ cmd.name }}"
+
+    def test_{{ cmd.name|replace('-', '_') }}_version_format(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert re.match(r"^\d+\.\d+\.\d+$", payload["skill_version"])
+
+    def test_{{ cmd.name|replace('-', '_') }}_summary_present(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--output", "json"])
+        payload = json.loads(result.stdout)
+        summary = payload["output"]["summary"]
+        assert isinstance(summary, str)
+        assert 0 < len(summary) <= 500
+
+    def test_{{ cmd.name|replace('-', '_') }}_stdout_clean_json(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--output", "json"])
+        json.loads(result.stdout)
+
+{% if cmd.has_dry_run %}
+    def test_{{ cmd.name|replace('-', '_') }}_dry_run_status(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["{{ cmd.name }}", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "dry_run"
+        assert "dry_run_report" in payload
+{% endif %}
+
+
+{% endfor %}
+# ---------------------------------------------------------------------------
+# Contrat sécurité
+# ---------------------------------------------------------------------------
+
+class TestNoSecretsLeaked:
+    FORBIDDEN_PATTERNS = ["PRIVATE KEY", "BEGIN RSA", "api_key=", "password=",
+                          "ghp_", "sk-ant-"]
+
+    @pytest.mark.parametrize("command_args", [
+        ["--help"], ["--version"],
+        {% for cmd in commands %}["{{ cmd.name }}", "--output", "json"],
+        {% endfor %}
+    ])
+    def test_no_secret_in_output(self, runner: CliRunner, command_args: list[str]) -> None:
+        result = runner.invoke(app, command_args)
+        combined = (result.stdout or "") + (result.stderr or "")
+        for pattern in self.FORBIDDEN_PATTERNS:
+            assert pattern not in combined
+
+
+# ---------------------------------------------------------------------------
+# Contrat exit codes
+# ---------------------------------------------------------------------------
+
+class TestExitCodes:
+    def test_unknown_command_returns_code_2(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["commande-inexistante"])
+        assert result.exit_code == 2

--- a/tests/cli_contracts/test_tk_installer.py
+++ b/tests/cli_contracts/test_tk_installer.py
@@ -1,0 +1,218 @@
+"""Tests CliRunner pour tk-installer v0.1.
+
+Valide le contrat skill_output.schema.json (DEC-005) et le standard
+implémentation Typer (docs/cli_forge_typer_standard.md) :
+
+- --help retourne 0
+- --version retourne 0 et affiche la version
+- status et diagnose produisent un JSON conforme au schéma officiel
+- summary obligatoire, ≤ 500 chars
+- Pas de secrets en sortie
+- Codes de sortie respectés
+- Anti-écrasement actif (--force requis)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from tools.tk_installer.tk_installer import (
+    CLI_NAME,
+    CLI_VERSION,
+    VALID_STATUSES,
+    app,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CliRunner Typer (Click 8.2+ : stdout/stderr séparés par défaut)."""
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Contrat universel : help, version
+# ---------------------------------------------------------------------------
+
+class TestContractHelp:
+    def test_help_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+
+    def test_help_mentions_cli_name(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert "tk-installer" in result.stdout or "tk_installer" in result.stdout
+
+    def test_help_lists_commands(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert "status" in result.stdout
+        assert "diagnose" in result.stdout
+
+
+class TestContractVersion:
+    def test_version_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+
+    def test_version_shows_value(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert CLI_VERSION in result.stdout
+
+    def test_version_shows_cli_name(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert CLI_NAME in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Contrat skill_output.schema.json — status
+# ---------------------------------------------------------------------------
+
+class TestSchemaStatus:
+    """status doit produire un JSON conforme au schéma."""
+
+    def test_status_json_is_parseable(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, dict)
+
+    def test_status_required_fields(self, runner: CliRunner) -> None:
+        """Champs `required` du schéma."""
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        for field in ("status", "skill_name", "skill_version", "timestamp", "output"):
+            assert field in payload, f"Champ obligatoire manquant : {field}"
+        assert payload["status"] in VALID_STATUSES
+
+    def test_status_skill_name_namespaced(self, runner: CliRunner) -> None:
+        """skill_name doit identifier la CLI + la commande."""
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["skill_name"] == f"{CLI_NAME}.status"
+
+    def test_status_version_format(self, runner: CliRunner) -> None:
+        """Le schéma impose semver X.Y.Z."""
+        import re
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert re.match(r"^\d+\.\d+\.\d+$", payload["skill_version"])
+
+    def test_status_timestamp_iso_z(self, runner: CliRunner) -> None:
+        """timestamp doit être ISO 8601 (suffixe Z attendu)."""
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        ts = payload["timestamp"]
+        assert ts.endswith("Z") or "+" in ts, f"Timestamp non ISO 8601 : {ts}"
+
+    def test_status_output_has_summary(self, runner: CliRunner) -> None:
+        """output.summary est obligatoire, ≤ 500 chars."""
+        result = runner.invoke(app, ["status", "--output", "json"])
+        payload = json.loads(result.stdout)
+        summary = payload["output"]["summary"]
+        assert isinstance(summary, str)
+        assert 0 < len(summary) <= 500
+
+    def test_status_stdout_clean_json(self, runner: CliRunner) -> None:
+        """stdout en mode json = JSON pur, pas de logs rich."""
+        result = runner.invoke(app, ["status", "--output", "json"])
+        json.loads(result.stdout)  # lève si pollué
+
+
+# ---------------------------------------------------------------------------
+# Contrat skill_output.schema.json — diagnose
+# ---------------------------------------------------------------------------
+
+class TestSchemaDiagnose:
+    def test_diagnose_json_is_parseable(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, dict)
+
+    def test_diagnose_required_fields(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        for field in ("status", "skill_name", "skill_version", "timestamp", "output"):
+            assert field in payload
+        assert payload["status"] in VALID_STATUSES
+
+    def test_diagnose_skill_name_namespaced(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["skill_name"] == f"{CLI_NAME}.diagnose"
+
+    def test_diagnose_reports_environment(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        env = payload["output"]["data"].get("environment", {})
+        assert "python" in env
+        assert "os" in env
+
+    def test_diagnose_dry_run_status(self, runner: CliRunner) -> None:
+        """En mode --dry-run, status = 'dry_run'."""
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "dry_run"
+
+    def test_diagnose_dry_run_has_report(self, runner: CliRunner) -> None:
+        """status=dry_run impose la présence de dry_run_report."""
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert "dry_run_report" in payload
+        rr = payload["dry_run_report"]
+        assert "actions_that_would_run" in rr
+        assert "risk_level" in rr
+        assert rr["risk_level"] in {"LOW", "MEDIUM", "HIGH", "CRITICAL"}
+
+    def test_diagnose_dry_run_does_not_create_files(self, runner: CliRunner) -> None:
+        """--dry-run ne crée aucun fichier (output.files_created vide)."""
+        result = runner.invoke(app, ["diagnose", "--dry-run", "--output", "json"])
+        payload = json.loads(result.stdout)
+        assert payload["output"].get("files_created", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Contrat sécurité : pas de secrets
+# ---------------------------------------------------------------------------
+
+class TestNoSecretsLeaked:
+    FORBIDDEN_PATTERNS = [
+        "PRIVATE KEY", "BEGIN RSA",
+        "api_key=", "password=",
+        "ghp_", "sk-ant-",
+    ]
+
+    @pytest.mark.parametrize("command_args", [
+        ["--help"],
+        ["--version"],
+        ["status", "--output", "json"],
+        ["diagnose", "--dry-run", "--output", "json"],
+    ])
+    def test_no_secret_in_output(self, runner: CliRunner, command_args: list[str]) -> None:
+        result = runner.invoke(app, command_args)
+        combined = (result.stdout or "") + (result.stderr or "")
+        for pattern in self.FORBIDDEN_PATTERNS:
+            assert pattern not in combined, (
+                f"Secret potentiel '{pattern}' dans la sortie de {command_args}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Contrat exit codes
+# ---------------------------------------------------------------------------
+
+class TestExitCodes:
+    def test_unknown_command_returns_code_2(self, runner: CliRunner) -> None:
+        """Mauvais usage CLI = 2 (Typer)."""
+        result = runner.invoke(app, ["commande-inexistante"])
+        assert result.exit_code == 2
+
+    def test_help_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+
+    def test_version_returns_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Configuration partagée pytest — injecte la racine du repo dans sys.path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Racine du repo = parent du dossier tests/
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tools/tk_installer/tk_installer.py
+++ b/tools/tk_installer/tk_installer.py
@@ -1,0 +1,462 @@
+"""TricorderKit phased installer (v0.1).
+
+CLI Typer conforme à `core/contracts/skill_output.schema.json` (DEC-005)
+et au standard implémentation `docs/cli_forge_typer_standard.md`.
+
+Commandes :
+  - status   : affiche l'état des phases TricorderKit (lit .tricorderkit/state.yml)
+  - diagnose : diagnostique l'environnement et les fichiers TricorderKit clés
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+# ---------------------------------------------------------------------------
+# Constantes (exportées pour les tests CliRunner)
+# ---------------------------------------------------------------------------
+
+CLI_NAME = "tk-installer"
+CLI_VERSION = "0.1.0"
+
+# Exit codes standardisés (cf. docs/cli_forge_typer_standard.md §3.6)
+EXIT_OK = 0
+EXIT_BUSINESS_ERROR = 1
+EXIT_ENV_KO = 3
+EXIT_GATE_BLOCKED = 4
+EXIT_CONFLICT = 5
+
+# Statuts conformes au schéma skill_output.schema.json
+VALID_STATUSES = {"success", "partial", "error", "dry_run"}
+
+# ---------------------------------------------------------------------------
+# App Typer
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(
+    name=CLI_NAME,
+    help="TricorderKit phased installer — status, diagnose (v0.1).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+# rich envoyé sur stderr → stdout reste propre en mode --output json
+console = Console(stderr=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso_utc_z() -> str:
+    """Instant courant ISO 8601 UTC avec suffixe 'Z' (conforme JSON Schema)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _find_repo_root(start: Path | None = None) -> Path:
+    """Remonte jusqu'à trouver la racine du repo TricorderKit.
+
+    Critères acceptés (l'un suffit) :
+      - présence d'un dossier .git
+      - présence d'un dossier .tricorderkit
+      - présence d'un dossier .planning
+    """
+    here = (start or Path.cwd()).resolve()
+    for candidate in (here, *here.parents):
+        if any((candidate / marker).exists()
+               for marker in (".git", ".tricorderkit", ".planning")):
+            return candidate
+    raise RuntimeError(
+        f"Racine du repo introuvable depuis {here}. "
+        "Aucun marqueur .git / .tricorderkit / .planning détecté."
+    )
+
+
+def _run_silent(cmd: list[str], timeout: int = 5) -> dict[str, Any]:
+    """Lance une commande système sans lever d'exception."""
+    if shutil.which(cmd[0]) is None:
+        return {"available": False, "version": None}
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        version_lines = (result.stdout or result.stderr or "").strip().splitlines()
+        return {
+            "available": result.returncode == 0,
+            "version": version_lines[0] if version_lines else None,
+        }
+    except (subprocess.TimeoutExpired, OSError):
+        return {"available": False, "version": None}
+
+
+def _load_state(repo_root: Path) -> dict[str, Any] | None:
+    """Charge .tricorderkit/state.yml ou retourne None si absent/invalide."""
+    state_file = repo_root / ".tricorderkit" / "state.yml"
+    if not state_file.exists():
+        return None
+    try:
+        with state_file.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except (yaml.YAMLError, OSError):
+        return None
+
+
+def emit_result(
+    command: str,
+    status: str,
+    summary: str,
+    data: dict[str, Any] | None = None,
+    files_created: list[str] | None = None,
+    next_steps: list[str] | None = None,
+    error_details: dict[str, Any] | None = None,
+    dry_run_report: dict[str, Any] | None = None,
+    output_format: str = "pretty",
+    duration_ms: int = 0,
+    pretty_renderer: Any = None,
+) -> int:
+    """Émet un payload conforme à skill_output.schema.json.
+
+    Retourne l'exit code adapté au status :
+      - success → 0
+      - partial → 1
+      - dry_run → 0
+      - error   → 1 par défaut (à overrider par typer.Exit(code=X) côté caller)
+    """
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Statut invalide : {status!r}. Attendu : {VALID_STATUSES}")
+    if len(summary) > 500:
+        # Le schéma impose maxLength=500 sur output.summary
+        summary = summary[:497] + "..."
+
+    # Payload conforme schema
+    payload: dict[str, Any] = {
+        "status": status,
+        "skill_name": f"{CLI_NAME}.{command}",
+        "skill_version": CLI_VERSION,
+        "timestamp": _now_iso_utc_z(),
+        "duration_ms": duration_ms,
+        "output": {
+            "summary": summary,
+            "data": data or {},
+            "files_created": files_created or [],
+            "next_steps": (next_steps or [])[:5],  # schema maxItems=5
+        },
+    }
+    if status == "error" and error_details:
+        payload["error"] = error_details
+    if status == "dry_run" and dry_run_report:
+        payload["dry_run_report"] = dry_run_report
+
+    # Émission
+    if output_format == "json":
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2))
+        sys.stdout.write("\n")
+    else:
+        color = {
+            "success": "green", "partial": "yellow",
+            "error": "red", "dry_run": "cyan",
+        }[status]
+        console.print(f"[{color}]{command} → {status}[/{color}]")
+        console.print(summary)
+        if pretty_renderer is not None:
+            console.print(pretty_renderer)
+        if data and pretty_renderer is None:
+            console.print(data)
+        if status == "error" and error_details:
+            console.print(f"[red]Erreur: {error_details.get('message', '')}[/red]")
+        if next_steps:
+            console.print("[cyan]Prochaines étapes :[/cyan]")
+            for step in next_steps[:5]:
+                console.print(f"  • {step}")
+
+    return EXIT_OK if status in ("success", "dry_run") else EXIT_BUSINESS_ERROR
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"{CLI_NAME} {CLI_VERSION}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", callback=_version_callback, is_eager=True,
+        help="Affiche la version et quitte.",
+    ),
+) -> None:
+    """Point d'entrée racine."""
+
+
+# ---------------------------------------------------------------------------
+# Commande : status
+# ---------------------------------------------------------------------------
+
+@app.command("status")
+def status_cmd(
+    output: str = typer.Option(
+        "pretty", "--output", "-o", help="Format de sortie : pretty ou json.",
+    ),
+) -> None:
+    """Affiche l'état des phases TricorderKit (lit .tricorderkit/state.yml)."""
+    start = time.perf_counter()
+
+    try:
+        repo_root = _find_repo_root()
+    except RuntimeError as exc:
+        duration = int((time.perf_counter() - start) * 1000)
+        emit_result(
+            command="status", status="error",
+            summary="Racine du repo TricorderKit introuvable.",
+            error_details={
+                "code": "REPO_ROOT_NOT_FOUND",
+                "message": str(exc),
+                "recoverable": True,
+                "rollback_available": False,
+            },
+            next_steps=["Se placer à la racine du repo TricorderKit avant de lancer."],
+            output_format=output, duration_ms=duration,
+        )
+        raise typer.Exit(code=EXIT_ENV_KO)
+
+    state = _load_state(repo_root)
+    if state is None:
+        duration = int((time.perf_counter() - start) * 1000)
+        emit_result(
+            command="status", status="error",
+            summary=".tricorderkit/state.yml absent ou invalide.",
+            data={"repo_root": str(repo_root)},
+            error_details={
+                "code": "STATE_FILE_MISSING",
+                "message": "Le fichier .tricorderkit/state.yml est absent ou ne parse pas.",
+                "recoverable": True,
+                "rollback_available": False,
+            },
+            next_steps=["Créer .tricorderkit/state.yml (bootstrap Phase 0)."],
+            output_format=output, duration_ms=duration,
+        )
+        raise typer.Exit(code=EXIT_BUSINESS_ERROR)
+
+    phases = state.get("phases", {}) or {}
+    blockers: list[str] = []
+    next_actions: list[str] = []
+    verified_count = 0
+    total_count = len(phases)
+
+    for phase_key, phase_data in phases.items():
+        pd = phase_data or {}
+        if pd.get("verified"):
+            verified_count += 1
+        if pd.get("status") == "blocked":
+            blocked_by = pd.get("blocked_by", []) or []
+            blockers.append(f"{phase_key} ← {', '.join(blocked_by) or 'unknown'}")
+        if not next_actions and pd.get("status") in ("pending", "in_progress"):
+            next_actions.append(f"Avancer sur {phase_key}.")
+
+    # Rendu pretty
+    table = Table(title=f"TricorderKit v{state.get('version', '?')} — Phases")
+    table.add_column("Phase", style="cyan")
+    table.add_column("Status", style="white")
+    table.add_column("Verified", style="green")
+    table.add_column("Blocked by", style="yellow")
+    for phase_key, phase_data in phases.items():
+        pd = phase_data or {}
+        blocked_by = ", ".join(pd.get("blocked_by", []) or [])
+        table.add_row(
+            phase_key, str(pd.get("status", "?")),
+            "OK" if pd.get("verified") else "--",
+            blocked_by,
+        )
+
+    summary = f"{verified_count}/{total_count} phases verified. {len(blockers)} blocker(s)."
+    duration = int((time.perf_counter() - start) * 1000)
+
+    emit_result(
+        command="status", status="success", summary=summary,
+        data={
+            "version": state.get("version"),
+            "install_status": state.get("install_status"),
+            "phases": phases,
+            "blockers": blockers,
+            "verified_count": verified_count,
+            "total_count": total_count,
+        },
+        next_steps=next_actions or ["Toutes les phases gérées sont actives."],
+        output_format=output, duration_ms=duration, pretty_renderer=table,
+    )
+    raise typer.Exit(code=EXIT_OK)
+
+
+# ---------------------------------------------------------------------------
+# Commande : diagnose
+# ---------------------------------------------------------------------------
+
+@app.command("diagnose")
+def diagnose_cmd(
+    output: str = typer.Option(
+        "pretty", "--output", "-o", help="Format de sortie : pretty ou json.",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="N'écrit aucun rapport sur disque.",
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Écrase un rapport existant (avec backup).",
+    ),
+) -> None:
+    """Diagnostique l'environnement et la présence des fichiers TricorderKit clés."""
+    start = time.perf_counter()
+
+    try:
+        repo_root = _find_repo_root()
+    except RuntimeError as exc:
+        duration = int((time.perf_counter() - start) * 1000)
+        emit_result(
+            command="diagnose", status="error",
+            summary="Racine du repo TricorderKit introuvable.",
+            error_details={
+                "code": "REPO_ROOT_NOT_FOUND",
+                "message": str(exc),
+                "recoverable": True,
+                "rollback_available": False,
+            },
+            output_format=output, duration_ms=duration,
+        )
+        raise typer.Exit(code=EXIT_ENV_KO)
+
+    # Détection environnement
+    env_info = {
+        "os": platform.system(),
+        "os_release": platform.release(),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "git": _run_silent(["git", "--version"]),
+        "docker": _run_silent(["docker", "--version"]),
+        "node": _run_silent(["node", "--version"]),
+    }
+
+    # Vérification fichiers clés
+    expected_files = [
+        ".tricorderkit/state.yml",
+        ".tricorderkit/phase_gates.yml",
+        ".tricorderkit/install_profile.yml",
+        "scripts/validate_repo.py",
+        "scripts/health_check.py",
+        ".planning/STATE.md",
+    ]
+    files_status = {p: (repo_root / p).exists() for p in expected_files}
+    missing = [p for p, present in files_status.items() if not present]
+
+    # Mode dry-run : émettre un dry_run_report
+    if dry_run:
+        duration = int((time.perf_counter() - start) * 1000)
+        emit_result(
+            command="diagnose", status="dry_run",
+            summary=f"Simulation: {len(expected_files) - len(missing)}/{len(expected_files)} fichiers présents.",
+            data={
+                "repo_root": str(repo_root),
+                "environment": env_info,
+                "files": files_status,
+                "missing": missing,
+            },
+            dry_run_report={
+                "actions_that_would_run": [
+                    "Écrire reports/install/diagnose_YYYY-MM-DD.md",
+                ],
+                "estimated_tokens": 0,
+                "estimated_duration_ms": 50,
+                "risk_level": "LOW",
+            },
+            next_steps=["Relancer sans --dry-run pour générer le rapport."],
+            output_format=output, duration_ms=duration,
+        )
+        raise typer.Exit(code=EXIT_OK)
+
+    # Mode normal : écrire le rapport
+    reports_dir = repo_root / "reports" / "install"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    date_tag = datetime.now().strftime("%Y-%m-%d")
+    report_path = reports_dir / f"diagnose_{date_tag}.md"
+
+    # Anti-écrasement
+    if report_path.exists() and not force:
+        duration = int((time.perf_counter() - start) * 1000)
+        emit_result(
+            command="diagnose", status="error",
+            summary=f"Rapport {report_path.name} existe déjà. --force requis.",
+            error_details={
+                "code": "FILE_EXISTS",
+                "message": f"{report_path} existe déjà. Utiliser --force pour écraser (backup auto).",
+                "recoverable": True,
+                "rollback_available": True,
+            },
+            next_steps=[
+                f"Relancer avec --force",
+                f"Ou supprimer {report_path}",
+            ],
+            output_format=output, duration_ms=duration,
+        )
+        raise typer.Exit(code=EXIT_CONFLICT)
+
+    # Backup si écrasement
+    if report_path.exists() and force:
+        backup_dir = reports_dir / "backups" / date_tag
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_name = f"{report_path.stem}_{int(time.time())}.md"
+        shutil.copy2(report_path, backup_dir / backup_name)
+
+    # Écriture du rapport Markdown
+    lines = [
+        f"# Diagnose Report — {date_tag}", "",
+        f"- Repo root : `{repo_root}`",
+        f"- OS : {env_info['os']} {env_info['os_release']}",
+        f"- Python : {env_info['python']}",
+        f"- Git : {env_info['git'].get('version') or 'absent'}",
+        f"- Docker : {env_info['docker'].get('version') or 'absent'}",
+        f"- Node : {env_info['node'].get('version') or 'absent'}",
+        "", "## Fichiers attendus", "",
+    ]
+    for p, present in files_status.items():
+        lines.append(f"- {'OK' if present else '--'} `{p}`")
+    if missing:
+        lines += ["", "## Manquants", ""] + [f"- {m}" for m in missing]
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+
+    overall_status = "success" if not missing and env_info["git"]["available"] else "partial"
+    summary = f"Diagnose: {len(expected_files) - len(missing)}/{len(expected_files)} files, "
+    summary += f"git={'ok' if env_info['git']['available'] else 'absent'}."
+
+    duration = int((time.perf_counter() - start) * 1000)
+    emit_result(
+        command="diagnose", status=overall_status, summary=summary,
+        data={
+            "repo_root": str(repo_root),
+            "environment": env_info,
+            "files": files_status,
+            "missing": missing,
+        },
+        files_created=[str(report_path)],
+        next_steps=["tk-installer status"] if not missing
+                   else [f"Créer : {m}" for m in missing[:3]],
+        output_format=output, duration_ms=duration,
+    )
+    raise typer.Exit(code=EXIT_OK if overall_status == "success" else EXIT_BUSINESS_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Objectif

Phase 2 cli-forge consolidation : aligner toutes les CLIs sur le schéma
officiel `skill_output.schema.json` (DEC-005) et introduire Typer comme
standard pour les nouvelles CLIs (DEC-010).

Phase 2 v0.7 avait été marquée "terminée" sans standard d'implémentation
Typer ni tests CliRunner. Cette PR consolide en ajoutant :

- standard d'implémentation Typer documenté
- templates Jinja2 réutilisables
- première CLI Typer de référence (tk-installer minimal)
- tests CliRunner exhaustifs (27 tests)
- gouvernance plugin cli-forge (SKILL, manifest, README)
- orchestration phasée v0.8 dans `.tricorderkit/`

## Phase concernée

Phase 2 (CLI-first) — consolidation. Phase 3 RAG/Graphify reste prioritaire
et non bloquée.

## Fichiers créés (14)

- `docs/cli_forge_typer_standard.md`
- `plugins/cli-forge/{README.md, SKILL.md, manifest.yml}`
- `plugins/cli-forge/templates/{typer_cli, typer_test}.py.j2`
- `tools/tk_installer/{__init__.py, tk_installer.py}`
- `tests/{conftest.py, cli_contracts/test_tk_installer.py}`
- `.tricorderkit/{state, phase_gates, install_profile, known_errors}.yml`

## Fichiers modifiés (4)

- `.gitignore` — ignore `reports/`
- `.planning/STATE.md` — section "Phase 2 consolidation 2026-05-13"
- `.planning/DECISIONS.md` — DEC-010, DEC-011, DEC-012
- `plugins/cli-forge/registry.yml` — ajout tk-installer + tag `framework: argparse_legacy` sur github-goat

## Tests lancés

- `pytest tests/cli_contracts/test_tk_installer.py` → **27/27 verts**
- `python plugins/cli-forge/scripts/validate_cli_manifest.py --all` → warnings seulement (sécurité audit pending)
- `python scripts/validate_repo.py` → **100% HEALTHY**
- `python scripts/health_check.py` → état attendu

## Décisions

- **DEC-010** — Standard Typer pour nouvelles CLIs
- **DEC-011** — `tools/tk_installer/` snake_case (écart spec assumé)
- **DEC-012** — tk-installer minimal scope (status + diagnose seulement en v0.1)

## Limites connues (à traiter en PR séparées)

- `cli_manifest.schema.json` à étendre pour supporter `category: internal-tool` → tk-installer pourra avoir un vrai manifest
- `github-goat` et `source-watch-goat` à migrer en Typer → PRs dédiées
- DeprecationWarning `datetime.utcnow()` dans `validate_repo.py` et `health_check.py` → patch léger

## Rollback

```bash
git revert b01c8d0
```

Backup des fichiers remplacés disponible dans
`reports/install/backups/phase2_consolidation_2026-05-13_111520/`